### PR TITLE
1.19.2: Fix compatibility with Fabric API 0.77.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.19
-yarn_mappings=1.19+build.2
-loader_version=0.14.7
+minecraft_version=1.19.2
+yarn_mappings=1.19.2+build.28
+loader_version=0.14.25
 #Fabric api
-fabric_version=0.50.0+1.19
+fabric_version=0.77.0+1.19.2
 
 # Mod Properties
 mod_version = 1.9.0
@@ -19,8 +19,8 @@ archives_base_name = satin
 findbugs_version = 3.0.2
 jb_annotations_version = 18.0.0
 apiguardian_version = 1.0.0
-modmenu_version = 4.0.0
-iris_version = mc1.18.1-1.1.3
+modmenu_version = 4.1.2
+iris_version = 1.6.11+1.19.2
 
 #Publishing
 display_name = Satin

--- a/src/main/java/ladysnake/satin/Satin.java
+++ b/src/main/java/ladysnake/satin/Satin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/EntitiesPostRenderCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/EntitiesPostRenderCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/EntitiesPreRenderCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/EntitiesPreRenderCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/PickEntityShaderCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/PickEntityShaderCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/PostWorldRenderCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/PostWorldRenderCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/PostWorldRenderCallbackV2.java
+++ b/src/main/java/ladysnake/satin/api/event/PostWorldRenderCallbackV2.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/ResolutionChangeCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/ResolutionChangeCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/ShaderEffectRenderCallback.java
+++ b/src/main/java/ladysnake/satin/api/event/ShaderEffectRenderCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/event/package-info.java
+++ b/src/main/java/ladysnake/satin/api/event/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/experimental/ReadableDepthFramebuffer.java
+++ b/src/main/java/ladysnake/satin/api/experimental/ReadableDepthFramebuffer.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/ManagedCoreShader.java
+++ b/src/main/java/ladysnake/satin/api/managed/ManagedCoreShader.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/ManagedFramebuffer.java
+++ b/src/main/java/ladysnake/satin/api/managed/ManagedFramebuffer.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/ManagedShaderEffect.java
+++ b/src/main/java/ladysnake/satin/api/managed/ManagedShaderEffect.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/ShaderEffectManager.java
+++ b/src/main/java/ladysnake/satin/api/managed/ShaderEffectManager.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/package-info.java
+++ b/src/main/java/ladysnake/satin/api/managed/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/SamplerUniform.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/SamplerUniform.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/SamplerUniformV2.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/SamplerUniformV2.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform1f.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform1f.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform1i.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform1i.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform2f.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform2f.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform2i.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform2i.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform3f.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform3f.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform3i.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform3i.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform4f.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform4f.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/Uniform4i.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/Uniform4i.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/UniformFinder.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/UniformFinder.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/managed/uniform/UniformMat4.java
+++ b/src/main/java/ladysnake/satin/api/managed/uniform/UniformMat4.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/GlMatrices.java
+++ b/src/main/java/ladysnake/satin/api/util/GlMatrices.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/RenderLayerHelper.java
+++ b/src/main/java/ladysnake/satin/api/util/RenderLayerHelper.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/ShaderLinkException.java
+++ b/src/main/java/ladysnake/satin/api/util/ShaderLinkException.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/ShaderLoader.java
+++ b/src/main/java/ladysnake/satin/api/util/ShaderLoader.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/ShaderPrograms.java
+++ b/src/main/java/ladysnake/satin/api/util/ShaderPrograms.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/api/util/package-info.java
+++ b/src/main/java/ladysnake/satin/api/util/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/BlockRenderLayerRegistry.java
+++ b/src/main/java/ladysnake/satin/impl/BlockRenderLayerRegistry.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/FramebufferWrapper.java
+++ b/src/main/java/ladysnake/satin/impl/FramebufferWrapper.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformBase.java
+++ b/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformBase.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformV1.java
+++ b/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformV1.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformV2.java
+++ b/src/main/java/ladysnake/satin/impl/ManagedSamplerUniformV2.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ManagedUniform.java
+++ b/src/main/java/ladysnake/satin/impl/ManagedUniform.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ManagedUniformBase.java
+++ b/src/main/java/ladysnake/satin/impl/ManagedUniformBase.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ReloadableShaderEffectManager.java
+++ b/src/main/java/ladysnake/satin/impl/ReloadableShaderEffectManager.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/RenderLayerDuplicator.java
+++ b/src/main/java/ladysnake/satin/impl/RenderLayerDuplicator.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/RenderLayerSupplier.java
+++ b/src/main/java/ladysnake/satin/impl/RenderLayerSupplier.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ResettableManagedCoreShader.java
+++ b/src/main/java/ladysnake/satin/impl/ResettableManagedCoreShader.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ResettableManagedShaderBase.java
+++ b/src/main/java/ladysnake/satin/impl/ResettableManagedShaderBase.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ResettableManagedShaderEffect.java
+++ b/src/main/java/ladysnake/satin/impl/ResettableManagedShaderEffect.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/SamplerAccess.java
+++ b/src/main/java/ladysnake/satin/impl/SamplerAccess.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/ValidatingShaderLoader.java
+++ b/src/main/java/ladysnake/satin/impl/ValidatingShaderLoader.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/impl/package-info.java
+++ b/src/main/java/ladysnake/satin/impl/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/SatinMixinPlugin.java
+++ b/src/main/java/ladysnake/satin/mixin/SatinMixinPlugin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/SatinMixinPlugin.java
+++ b/src/main/java/ladysnake/satin/mixin/SatinMixinPlugin.java
@@ -72,7 +72,8 @@ public final class SatinMixinPlugin implements IMixinConfigPlugin {
     public List<String> getMixins() {
         List<String> compatMixins = new ArrayList<>();
         if (FabricLoader.getInstance().isModLoaded("iris")) {
-            compatMixins.add("iris.IrisRenderLayerWrapperMixin");
+            compatMixins.add("iris.InnerWrappedRenderTypeMixin");
+            compatMixins.add("iris.OuterWrappedRenderTypeMixin");
         }
         return compatMixins;
     }

--- a/src/main/java/ladysnake/satin/mixin/client/AccessiblePassesShaderEffect.java
+++ b/src/main/java/ladysnake/satin/mixin/client/AccessiblePassesShaderEffect.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/blockrenderlayer/RenderLayerMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/blockrenderlayer/RenderLayerMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/blockrenderlayer/WorldRendererMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/blockrenderlayer/WorldRendererMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/event/GameRendererMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/event/GameRendererMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/event/MinecraftClientMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/event/MinecraftClientMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/event/WorldRendererMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/event/WorldRendererMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/gl/CoreShaderMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/CoreShaderMixin.java
@@ -20,9 +20,7 @@ package ladysnake.satin.mixin.client.gl;
 import ladysnake.satin.impl.SamplerAccess;
 import net.minecraft.client.gl.Program;
 import net.minecraft.client.render.Shader;
-import net.minecraft.client.render.VertexFormat;
 import net.minecraft.resource.ResourceFactory;
-import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -30,7 +28,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
 import java.util.Map;
@@ -54,18 +51,6 @@ public abstract class CoreShaderMixin implements SamplerAccess {
 
     @Accessor("loadedSamplerIds")
     public abstract List<Integer> satin$getSamplerShaderLocs();
-
-    /**
-     * @see JsonEffectGlShaderMixin#constructProgramIdentifier(String, ResourceManager, String)
-     */
-    @Redirect(method = "<init>", at = @At(value = "NEW", target = "net/minecraft/util/Identifier", ordinal = 0))
-    private Identifier fixId(String arg, ResourceFactory factory, String name, VertexFormat format) {
-        if (!name.contains(":")) {
-            return new Identifier(arg);
-        }
-        Identifier split = new Identifier(name);
-        return new Identifier(split.getNamespace(), "shaders/core/" + split.getPath() + ".json");
-    }
 
     @ModifyVariable(method = "loadProgram", at = @At("STORE"), ordinal = 1)
     private static String fixPath(String path, final ResourceFactory factory, Program.Type type, String name) {

--- a/src/main/java/ladysnake/satin/mixin/client/gl/CoreShaderMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/CoreShaderMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/gl/DepthGlFramebufferMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/DepthGlFramebufferMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/gl/GlUniformMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/GlUniformMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/gl/JsonEffectGlShaderMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/JsonEffectGlShaderMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/gl/JsonEffectGlShaderMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/JsonEffectGlShaderMixin.java
@@ -19,15 +19,10 @@ package ladysnake.satin.mixin.client.gl;
 
 import ladysnake.satin.impl.SamplerAccess;
 import net.minecraft.client.gl.JsonEffectGlShader;
-import net.minecraft.client.gl.Program;
-import net.minecraft.resource.ResourceManager;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.gen.Accessor;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
 import java.util.Map;
@@ -58,54 +53,4 @@ public abstract class JsonEffectGlShaderMixin implements SamplerAccess {
     @Override
     @Accessor("samplerShaderLocs")
     public abstract List<Integer> satin$getSamplerShaderLocs();
-
-    /**
-     * Fix identifier creation to allow different namespaces
-     *
-     * <p>Why a redirect ?
-     * <ul>
-     * <li>Because letting the identifier be built will throw an exception, so no ModifyVariable</li>
-     * <li>Because we need to access the original id, so no ModifyArg (alternatively we could use 2 injections and a ThreadLocal but:)</li>
-     * <li>Because we assume other people who may want to do the same change can use this library</li>
-     * </ul>
-     * @param arg the string passed to the redirected Identifier constructor
-     * @param id the actual id passed as an argument to the method
-     * @return a new Identifier
-     */
-    @Redirect(
-            at = @At(
-                    value = "NEW",
-                    target = "net/minecraft/util/Identifier",
-                    ordinal = 0
-            ),
-            method = "<init>"
-    )
-    Identifier constructProgramIdentifier(String arg, ResourceManager unused, String id) {
-        if (!id.contains(":")) {
-            return new Identifier(arg);
-        }
-        Identifier split = new Identifier(id);
-        return new Identifier(split.getNamespace(), "shaders/program/" + split.getPath() + ".json");
-    }
-
-    /**
-     * @param arg the string passed to the redirected Identifier constructor
-     * @param id the actual id passed as an argument to the method
-     * @return a new Identifier
-     */
-    @Redirect(
-            at = @At(
-                    value = "NEW",
-                    target = "net/minecraft/util/Identifier",
-                    ordinal = 0
-            ),
-            method = "loadEffect"
-    )
-    private static Identifier constructProgramIdentifier(String arg, ResourceManager unused, Program.Type shaderType, String id) {
-        if (!arg.contains(":")) {
-            return new Identifier(arg);
-        }
-        Identifier split = new Identifier(id);
-        return new Identifier(split.getNamespace(), "shaders/program/" + split.getPath() + shaderType.getFileExtension());
-    }
 }

--- a/src/main/java/ladysnake/satin/mixin/client/gl/package-info.java
+++ b/src/main/java/ladysnake/satin/mixin/client/gl/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/iris/InnerWrappedRenderTypeMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/iris/InnerWrappedRenderTypeMixin.java
@@ -1,0 +1,48 @@
+/*
+ * Satin
+ * Copyright (C) 2019-2022 Ladysnake
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; If not, see <https://www.gnu.org/licenses>.
+ */
+package ladysnake.satin.mixin.client.iris;
+
+import ladysnake.satin.impl.RenderLayerDuplicator;
+import net.coderbot.iris.layer.InnerWrappedRenderType;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderPhase;
+import net.minecraft.client.render.VertexFormat;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.function.Consumer;
+
+@SuppressWarnings({"UnusedMixin", "unused"})    // added through mixin plugin
+@Mixin(InnerWrappedRenderType.class)
+public abstract class InnerWrappedRenderTypeMixin implements RenderLayerDuplicator.SatinRenderLayer {
+    @Shadow public abstract RenderLayer unwrap();
+
+    @Shadow @Final private RenderPhase extra;
+
+    @Override
+    public RenderLayer satin$copy(String newName, @Nullable VertexFormat vertexFormat, Consumer<RenderLayer.MultiPhaseParameters.Builder> op) {
+        return new InnerWrappedRenderType(newName, RenderLayerDuplicator.copy(this.unwrap(), newName + "_wrapped", vertexFormat, op), this.extra);
+    }
+
+    @Override
+    public RenderLayer.MultiPhaseParameters satin$copyPhaseParameters(Consumer<RenderLayer.MultiPhaseParameters.Builder> op) {
+        return RenderLayerDuplicator.copyPhaseParameters(this.unwrap(), op);
+    }
+}

--- a/src/main/java/ladysnake/satin/mixin/client/iris/InnerWrappedRenderTypeMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/iris/InnerWrappedRenderTypeMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/iris/OuterWrappedRenderTypeMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/iris/OuterWrappedRenderTypeMixin.java
@@ -18,9 +18,9 @@
 package ladysnake.satin.mixin.client.iris;
 
 import ladysnake.satin.impl.RenderLayerDuplicator;
-import net.coderbot.iris.layer.IrisRenderTypeWrapper;
-import net.coderbot.iris.layer.UseProgramRenderStateShard;
+import net.coderbot.iris.layer.OuterWrappedRenderType;
 import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderPhase;
 import net.minecraft.client.render.VertexFormat;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -30,15 +30,15 @@ import org.spongepowered.asm.mixin.Shadow;
 import java.util.function.Consumer;
 
 @SuppressWarnings({"UnusedMixin", "unused"})    // added through mixin plugin
-@Mixin(IrisRenderTypeWrapper.class)
-public abstract class IrisRenderLayerWrapperMixin implements RenderLayerDuplicator.SatinRenderLayer {
+@Mixin(OuterWrappedRenderType.class)
+public abstract class OuterWrappedRenderTypeMixin implements RenderLayerDuplicator.SatinRenderLayer {
     @Shadow public abstract RenderLayer unwrap();
 
-    @Shadow @Final private UseProgramRenderStateShard useProgram;
+    @Shadow @Final private RenderPhase extra;
 
     @Override
     public RenderLayer satin$copy(String newName, @Nullable VertexFormat vertexFormat, Consumer<RenderLayer.MultiPhaseParameters.Builder> op) {
-        return new IrisRenderTypeWrapper(newName, RenderLayerDuplicator.copy(this.unwrap(), newName + "_wrapped", vertexFormat, op), this.useProgram);
+        return new OuterWrappedRenderType(newName, RenderLayerDuplicator.copy(this.unwrap(), newName + "_wrapped", vertexFormat, op), this.extra);
     }
 
     @Override

--- a/src/main/java/ladysnake/satin/mixin/client/iris/OuterWrappedRenderTypeMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/iris/OuterWrappedRenderTypeMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/iris/package-info.java
+++ b/src/main/java/ladysnake/satin/mixin/client/iris/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerAccessor.java
+++ b/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerAccessor.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerMultiPhaseMixin.java
+++ b/src/main/java/ladysnake/satin/mixin/client/render/RenderLayerMultiPhaseMixin.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/render/RenderPhaseAccessor.java
+++ b/src/main/java/ladysnake/satin/mixin/client/render/RenderPhaseAccessor.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/mixin/client/render/package-info.java
+++ b/src/main/java/ladysnake/satin/mixin/client/render/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/java/ladysnake/satin/package-info.java
+++ b/src/main/java/ladysnake/satin/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,11 +30,10 @@
   ],
   "accessWidener": "satin.accesswidener",
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": "*",
     "fabric-api-base": "*",
     "fabric-resource-loader-v0": "*",
-    "minecraft": ">=1.18-",
-    "java": ">=16"
+    "minecraft": ">=1.19.2"
   },
   "conflicts": {
     "optifabric": "*"

--- a/src/test/java/ladysnake/satin/api/util/GlMatricesTest.java
+++ b/src/test/java/ladysnake/satin/api/util/GlMatricesTest.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satinbasictest/SatinBasicTest.java
+++ b/src/testmod/java/ladysnake/satinbasictest/SatinBasicTest.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satindepthtest/DepthFx.java
+++ b/src/testmod/java/ladysnake/satindepthtest/DepthFx.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satindepthtest/SatinDepthTest.java
+++ b/src/testmod/java/ladysnake/satindepthtest/SatinDepthTest.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satindepthtest/package-info.java
+++ b/src/testmod/java/ladysnake/satindepthtest/package-info.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satinrenderlayer/IllusionGolemEntityRenderer.java
+++ b/src/testmod/java/ladysnake/satinrenderlayer/IllusionGolemEntityRenderer.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satinrenderlayer/RainbowWitherEntityRenderer.java
+++ b/src/testmod/java/ladysnake/satinrenderlayer/RainbowWitherEntityRenderer.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satinrenderlayer/SatinRenderLayerTest.java
+++ b/src/testmod/java/ladysnake/satinrenderlayer/SatinRenderLayerTest.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satintestcore/SatinTestCore.java
+++ b/src/testmod/java/ladysnake/satintestcore/SatinTestCore.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satintestcore/block/SatinTestBlocks.java
+++ b/src/testmod/java/ladysnake/satintestcore/block/SatinTestBlocks.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satintestcore/item/DebugCallback.java
+++ b/src/testmod/java/ladysnake/satintestcore/item/DebugCallback.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satintestcore/item/DebugItem.java
+++ b/src/testmod/java/ladysnake/satintestcore/item/DebugItem.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/testmod/java/ladysnake/satintestcore/item/SatinTestItems.java
+++ b/src/testmod/java/ladysnake/satintestcore/item/SatinTestItems.java
@@ -1,6 +1,6 @@
 /*
  * Satin
- * Copyright (C) 2019-2022 Ladysnake
+ * Copyright (C) 2019-2023 Ladysnake
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
Fabric API 0.77.0+1.19.2 allows core shaders to be registered with a custom namespace ([source](https://github.com/FabricMC/fabric/commit/526f2c676d9b06a3d67bf25bf9ccedf554d9e897)), using mixins that conflict with Satin API's own. This PR simply removes the relevant mixins from Satin API, as they are no longer necessary.

I also updated the project's dependencies for 1.19.2. This included Iris, which I then had to amend the compat mixins for. I'm not 100% sure if I did so correctly, but a (very heavily modded) prod env showed no issues, so I guess it's fine?