### PR TITLE
Custom framebuffer formats: update to 1.21.2

### DIFF
--- a/src/main/java/org/ladysnake/satin/impl/CustomFormatFramebuffers.java
+++ b/src/main/java/org/ladysnake/satin/impl/CustomFormatFramebuffers.java
@@ -17,19 +17,69 @@
  */
 package org.ladysnake.satin.impl;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import net.minecraft.client.gl.Framebuffer;
+import net.minecraft.client.gl.PostEffectProcessor;
 import net.minecraft.client.gl.SimpleFramebuffer;
+import net.minecraft.client.gl.SimpleFramebufferFactory;
+import net.minecraft.client.render.FrameGraphBuilder;
+import net.minecraft.resource.Resource;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.StringIdentifiable;
+import net.minecraft.util.profiler.Profiler;
 import org.apiguardian.api.API;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL30;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 /**
  * Handles creating framebuffers with custom pixel formats.
+ * <p>
+ * For post-chains, this (along with some mixins) also handles a lot of the logic for implementing
+ * targets with custom formats. The data is shuffled around a lot, so here's a guide:
+ * <ul>
+ *     <li>Resource Loading starts.</li>
+ *     <ul>
+ *     <li>{@link net.minecraft.client.gl.ShaderLoader#prepare(ResourceManager, Profiler)} starts loading post-chains.</li>
+ *     <ul>
+ *         <li>{@link net.minecraft.client.gl.ShaderLoader#loadPostEffect(Identifier, Resource, ImmutableMap.Builder)}
+ *         is called for each post-chain.</li>
+ *         <li>In loadPostEffect, we parse the custom target formats and put them in LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID
+ *         ({@link #parseTargetFormatMap(Identifier, JsonElement)})</li>
+ *     </ul>
+ *     <li>The second phase of resource loading happens, and the prepared post-chains are put into a newly-created {@link net.minecraft.client.gl.ShaderLoader.Cache}.</li>
+ *     <li>In the cache's constructor, we copy from LOADING_TARGET_FORMATS_BY_POSTCHAIN into a field injected into the cache. ({@link #getPreparedTargetFormatMaps()})</li>
+ *     </ul>
+ *     <li>A post-chain processor ({@link net.minecraft.client.gl.PostEffectProcessor}) is created.</li>
+ *     <ul>
+ *         <li>The ShaderLoader cache's {@link net.minecraft.client.gl.ShaderLoader.Cache#loadProcessor(Identifier, Set)} is run.</li>
+ *         <li>In that method we find the post-chain's target format map (stored in the field we injected into the cache) and put it into TARGET_FORMATS_FOR_PROCESSOR_INIT. ({@link #prepareFormatsForProcessor(Map)})</li>
+ *         <li>In the post-chain processor's constructor, we take the map out of TARGET_FORMATS_FOR_PROCESSOR_INIT and put it into an injected field on the processor. ({@link #getFormatsForProcessor()})</li>
+ *     </ul>
+ *     <li>The post-chain processor is called for rendering (in one frame) ( {@link net.minecraft.client.gl.PostEffectProcessor#render(FrameGraphBuilder, int, int, PostEffectProcessor.FramebufferSet)})</li>
+ *     <ul>
+ *         <li>The processor creates new framebuffer factories for each of its targets.</li>
+ *         <li>When these factories are created, we look up the custom texture format for the target's ID and associate it with the factory in FORMATS_BY_FACTORY. ({@link #setCustomFormatForFactory(SimpleFramebufferFactory, TextureFormat)})</li>
+ *         <li>When the factory has its {@link SimpleFramebufferFactory#create()} method run, we remove the factory's custom texture format map entry and place it in FORMAT. ({@link #prepareCustomFormatForFramebufferInit(SimpleFramebufferFactory)})</li>
+ *         <li>In the framebuffer's constructor, we then take the format from FORMAT and use it. ({@link #getCustomFormatForFramebufferInit()})</li>
+ *     </ul>
+ * </ul>
+ *
  */
 public class CustomFormatFramebuffers {
     public static final String FORMAT_KEY = "satin:format";
     private static final ThreadLocal<TextureFormat> FORMAT = new ThreadLocal<>();
+    private static final ThreadLocal<Map<Identifier, TextureFormat>> TARGET_FORMATS_FOR_PROCESSOR_INIT = new ThreadLocal<>();
+    private static final Map<SimpleFramebufferFactory, TextureFormat> FORMATS_BY_FACTORY = new IdentityHashMap<>();
+    private static final Map<Identifier, Map<Identifier, TextureFormat>> LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID = new HashMap<>();
 
     /**
      * Experimental method to create a new framebuffer from code, please open an issue if you actually use it
@@ -46,36 +96,64 @@ public class CustomFormatFramebuffers {
         }
     }
 
-    /**
-     * Prepares a framebuffer creation for the given pixel format.
-     * <p>Valid formats are:</p>
-     * <ul>
-     *     <li>RGBA8</li>
-     *     <li>RGBA16</li>
-     *     <li>RGBA16F</li>
-     *     <li>RGBA32F</li>
-     * </ul>
-     * @param formatString  the pixel format, as specified by {@link TextureFormat#decode(String)}
-     */
-    public static void prepareCustomFormat(String formatString) {
-        // FORMAT's value is then consumed in gl.FramebufferMixin
-        FORMAT.set(TextureFormat.decode(formatString));
-    }
-
-    public static @Nullable CustomFormatFramebuffers.TextureFormat getCustomFormat() {
+    public static @Nullable CustomFormatFramebuffers.TextureFormat getCustomFormatForFramebufferInit() {
         return FORMAT.get();
     }
 
-    public static void clearCustomFormat() {
+    public static void clearCustomFormatForFramebufferInit() {
         FORMAT.remove();
     }
 
-    public enum TextureFormat {
+    public static void setCustomFormatForFactory(SimpleFramebufferFactory factory, TextureFormat format) {
+        FORMATS_BY_FACTORY.put(factory, format);
+    }
+
+    public static void prepareCustomFormatForFramebufferInit(SimpleFramebufferFactory factory) {
+        FORMAT.set(FORMATS_BY_FACTORY.remove(factory));
+    }
+
+    public static void parseTargetFormatMap(Identifier postChainId, JsonElement jsonElement) {
+        LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID.put(postChainId, makeTargetFormatMap(jsonElement));
+    }
+
+    public static Map<Identifier, Map<Identifier, TextureFormat>> getPreparedTargetFormatMaps() {
+        var res = Map.copyOf(LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID);
+        LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID.clear();
+        return res;
+    }
+
+    private static Map<Identifier, TextureFormat> makeTargetFormatMap(JsonElement jsonElement) {
+        if (jsonElement.isJsonObject()) {
+            var targets = jsonElement.getAsJsonObject().getAsJsonObject("targets");
+            if (targets != null && !targets.isEmpty()) {
+                return targets.entrySet().stream()
+                        .filter(e -> e.getValue().isJsonObject() && e.getValue().getAsJsonObject().has(FORMAT_KEY))
+                        .collect(Collectors.toMap(
+                                e -> Identifier.of(e.getKey()),
+                                e -> TextureFormat.CODEC.decode(JsonOps.INSTANCE, e.getValue().getAsJsonObject().get(FORMAT_KEY)).getOrThrow(JsonSyntaxException::new).getFirst()));
+            }
+        }
+        return Map.of();
+    }
+
+    public static void prepareFormatsForProcessor(Map<Identifier, TextureFormat> targetFormatMap) {
+        TARGET_FORMATS_FOR_PROCESSOR_INIT.set(targetFormatMap);
+    }
+
+    public static Map<Identifier, TextureFormat> getFormatsForProcessor() {
+        var res = TARGET_FORMATS_FOR_PROCESSOR_INIT.get();
+        TARGET_FORMATS_FOR_PROCESSOR_INIT.remove();
+        return res;
+    }
+
+    public enum TextureFormat implements StringIdentifiable {
         RGBA8(GL11.GL_RGBA8),
         RGBA16(GL11.GL_RGBA16),
         RGBA16F(GL30.GL_RGBA16F),
         RGBA32F(GL30.GL_RGBA32F),
         ;
+
+        public static final Codec<TextureFormat> CODEC = StringIdentifiable.createCodec(TextureFormat::values);
 
         public final int value;
 
@@ -104,6 +182,11 @@ public class CustomFormatFramebuffers {
 
         TextureFormat(int value) {
             this.value = value;
+        }
+
+        @Override
+        public String asString() {
+            return this.name();
         }
     }
 }

--- a/src/main/java/org/ladysnake/satin/impl/CustomFormatFramebuffers.java
+++ b/src/main/java/org/ladysnake/satin/impl/CustomFormatFramebuffers.java
@@ -78,6 +78,7 @@ public class CustomFormatFramebuffers {
     public static final String FORMAT_KEY = "satin:format";
     private static final ThreadLocal<TextureFormat> FORMAT = new ThreadLocal<>();
     private static final ThreadLocal<Map<Identifier, TextureFormat>> TARGET_FORMATS_FOR_PROCESSOR_INIT = new ThreadLocal<>();
+    // identity hash-map because SimpleFramebufferFactories are records
     private static final Map<SimpleFramebufferFactory, TextureFormat> FORMATS_BY_FACTORY = new IdentityHashMap<>();
     private static final Map<Identifier, Map<Identifier, TextureFormat>> LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID = new HashMap<>();
 

--- a/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatFramebufferMixin.java
+++ b/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatFramebufferMixin.java
@@ -40,10 +40,10 @@ public abstract class CustomFormatFramebufferMixin {
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void satin$setFormat(boolean useDepth, CallbackInfo ci) {
-        @Nullable CustomFormatFramebuffers.TextureFormat format = CustomFormatFramebuffers.getCustomFormat();
+        @Nullable CustomFormatFramebuffers.TextureFormat format = CustomFormatFramebuffers.getCustomFormatForFramebufferInit();
         if (format != null) {
             this.satin$format = format.value;
-            CustomFormatFramebuffers.clearCustomFormat();
+            CustomFormatFramebuffers.clearCustomFormatForFramebufferInit();
         }
     }
 

--- a/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatShaderLoaderMixin.java
+++ b/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatShaderLoaderMixin.java
@@ -1,0 +1,45 @@
+package org.ladysnake.satin.mixin.client.gl;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonElement;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.gl.PostEffectPipeline;
+import net.minecraft.client.gl.PostEffectProcessor;
+import net.minecraft.client.gl.ShaderLoader;
+import net.minecraft.resource.Resource;
+import net.minecraft.util.Identifier;
+import org.ladysnake.satin.impl.CustomFormatFramebuffers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.Map;
+import java.util.Set;
+
+@Mixin(ShaderLoader.class)
+public class CustomFormatShaderLoaderMixin {
+    @Inject(method = "loadPostEffect(Lnet/minecraft/util/Identifier;Lnet/minecraft/resource/Resource;Lcom/google/common/collect/ImmutableMap$Builder;)V",
+    at = @At(value = "INVOKE", target = "Lcom/mojang/serialization/Codec;parse(Lcom/mojang/serialization/DynamicOps;Ljava/lang/Object;)Lcom/mojang/serialization/DataResult;"))
+    private static void satin$parseCustomTargetFormats(Identifier id, Resource resource, ImmutableMap.Builder<Identifier, PostEffectPipeline> builder, CallbackInfo ci,
+                                                       @Local(ordinal = 1) Identifier targetId, @Local JsonElement jsonElement) {
+        CustomFormatFramebuffers.parseTargetFormatMap(id, jsonElement);
+    }
+
+    @Mixin(targets = "net.minecraft.client.gl.ShaderLoader$Cache")
+    static class CacheMixin {
+        private @Unique Map<Identifier, Map<Identifier, CustomFormatFramebuffers.TextureFormat>> targetFormats;
+
+        @Inject(method = "<init>", at = @At("RETURN"))
+        private void satin$cacheCustomTargetFormats(ShaderLoader shaderLoader, ShaderLoader.Definitions definitions, CallbackInfo ci) {
+            this.targetFormats = CustomFormatFramebuffers.getPreparedTargetFormatMaps();
+        }
+
+        @Inject(method = "loadProcessor", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gl/PostEffectProcessor;parseEffect(Lnet/minecraft/client/gl/PostEffectPipeline;Lnet/minecraft/client/texture/TextureManager;Lnet/minecraft/client/gl/ShaderLoader;Ljava/util/Set;)Lnet/minecraft/client/gl/PostEffectProcessor;"))
+        private void satin$prepareTargetsForProcessorMaking(Identifier id, Set<Identifier> availableExternalTargets, CallbackInfoReturnable<PostEffectProcessor> cir) {
+            CustomFormatFramebuffers.prepareFormatsForProcessor(this.targetFormats.get(id));
+        }
+    }
+}

--- a/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatSimpleFramebufferFactoryMixin.java
+++ b/src/main/java/org/ladysnake/satin/mixin/client/gl/CustomFormatSimpleFramebufferFactoryMixin.java
@@ -1,0 +1,17 @@
+package org.ladysnake.satin.mixin.client.gl;
+
+import net.minecraft.client.gl.Framebuffer;
+import net.minecraft.client.gl.SimpleFramebufferFactory;
+import org.ladysnake.satin.impl.CustomFormatFramebuffers;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SimpleFramebufferFactory.class)
+public abstract class CustomFormatSimpleFramebufferFactoryMixin {
+    @Inject(method = "create()Lnet/minecraft/client/gl/Framebuffer;", at = @At("HEAD"))
+    private void satin$prepareCustomFormat(CallbackInfoReturnable<Framebuffer> cir) {
+        CustomFormatFramebuffers.prepareCustomFormatForFramebufferInit((SimpleFramebufferFactory) (Object) this);
+    }
+}

--- a/src/main/resources/mixins.satin.client.json
+++ b/src/main/resources/mixins.satin.client.json
@@ -25,6 +25,9 @@
     "defaultRequire": 1
   },
   "client": [
+    "gl.CustomFormatShaderLoaderMixin",
+    "gl.CustomFormatShaderLoaderMixin$CacheMixin",
+    "gl.CustomFormatSimpleFramebufferFactoryMixin",
     "gl.ShaderLoaderMixin",
     "render.GameRendererAccessor",
     "render.WorldRendererMixin"

--- a/src/main/resources/satin.accesswidener
+++ b/src/main/resources/satin.accesswidener
@@ -11,3 +11,4 @@ accessible  class net/minecraft/client/render/RenderPhase$LineWidth
 accessible  class net/minecraft/client/render/RenderPhase$Toggleable
 accessible  class net/minecraft/client/render/RenderPhase$OffsetTexturing
 accessible  class net/minecraft/client/render/RenderPhase$Textures
+extendable  class net/minecraft/client/gl/PostEffectPipeline$Targets

--- a/src/main/resources/satin.accesswidener
+++ b/src/main/resources/satin.accesswidener
@@ -11,4 +11,3 @@ accessible  class net/minecraft/client/render/RenderPhase$LineWidth
 accessible  class net/minecraft/client/render/RenderPhase$Toggleable
 accessible  class net/minecraft/client/render/RenderPhase$OffsetTexturing
 accessible  class net/minecraft/client/render/RenderPhase$Textures
-extendable  class net/minecraft/client/gl/PostEffectPipeline$Targets

--- a/src/testmod/resources/assets/satincustomformattest/shaders/post/blit.json
+++ b/src/testmod/resources/assets/satincustomformattest/shaders/post/blit.json
@@ -1,47 +1,74 @@
 {
-  "targets": [
-    {
+  "targets": {
+    "swap": {
       "name": "swap",
       "satin:format": "RGBA8"
     },
-    {
-      "name": "swap16",
+    "swap16": {
       "satin:format": "RGBA16"
     },
-    {
-      "name": "swap16f",
+    "swap16f": {
       "satin:format": "RGBA16F"
     },
-    {
-      "name": "swap32f",
+    "swap32f": {
       "satin:format": "RGBA32F"
     }
-  ],
+  },
   "passes": [
     {
-      "name": "blit",
-      "intarget": "minecraft:main",
-      "outtarget": "swap"
+      "program": "blit",
+      "inputs": [
+        {
+          "sampler_name": "In",
+          "target": "minecraft:main",
+          "bilinear": true
+        }
+      ],
+      "output": "swap"
     },
     {
-      "name": "blit",
-      "intarget": "swap",
-      "outtarget": "swap16"
+      "program": "blit",
+      "inputs": [
+        {
+          "sampler_name": "In",
+          "target": "swap",
+          "bilinear": true
+        }
+      ],
+      "output": "swap16"
     },
     {
-      "name": "blit",
-      "intarget": "swap16",
-      "outtarget": "swap16f"
+      "program": "blit",
+      "inputs": [
+        {
+          "sampler_name": "In",
+          "target": "swap16",
+          "bilinear": true
+        }
+      ],
+      "output": "swap16f"
     },
     {
-      "name": "blit",
-      "intarget": "swap16f",
-      "outtarget": "swap32f"
+      "program": "blit",
+      "inputs": [
+        {
+          "sampler_name": "In",
+          "target": "swap16f",
+          "bilinear": true
+        }
+      ],
+      "output": "swap32f"
     },
     {
-      "name": "blit",
-      "intarget": "swap32f",
-      "outtarget": "minecraft:main"
+      "program": "blit",
+      "inputs": [
+        {
+          "sampler_name": "In",
+          "target": "swap32f",
+          "bilinear": true
+        }
+      ],
+      "output": "minecraft:main"
     }
   ]
 }


### PR DESCRIPTION
Everything is records and sealed interfaces and stuff now. It's hard to inject stuff into there without screwing everything up. Even if it compiles fine it might cause random `MatchException`s another day. So we're instead passing the data around a weird roundabout way:

1. Resource Loading starts.
    1. net.minecraft.client.gl.ShaderLoader#prepare(ResourceManager, Profiler) starts loading post-chains.
    1. net.minecraft.client.gl.ShaderLoader#loadPostEffect(Identifier, Resource, ImmutableMap.Builder) is called for each post-chain.
    1. In loadPostEffect, we parse the custom target formats and put them in LOADING_TARGET_FORMATS_BY_POSTCHAIN_ID (#parseTargetFormatMap(Identifier, JsonElement))
1. The second phase of resource loading happens, and the prepared post-chains are put into a newly-created net.minecraft.client.gl.ShaderLoader.Cache.
    1. In the cache's constructor, we copy from LOADING_TARGET_FORMATS_BY_POSTCHAIN into a field injected into the cache. (#getPreparedTargetFormatMaps())
1. A post-chain processor (net.minecraft.client.gl.PostEffectProcessor) is created.
    1. The ShaderLoader cache's net.minecraft.client.gl.ShaderLoader.Cache#loadProcessor(Identifier, Set) is run.
    1. In that method we find the post-chain's target format map (stored in the field we injected into the cache) and put it into TARGET_FORMATS_FOR_PROCESSOR_INIT. (#prepareFormatsForProcessor(Map))
    1. In the post-chain processor's constructor, we take the map out of TARGET_FORMATS_FOR_PROCESSOR_INIT and put it into an injected field on the processor. (#getFormatsForProcessor())
1. The post-chain processor is called for rendering (in one frame) ( net.minecraft.client.gl.PostEffectProcessor#render(FrameGraphBuilder, int, int, PostEffectProcessor.FramebufferSet))
    1. The processor creates new framebuffer factories for each of its targets.
    1. When these factories are created, we look up the custom texture format for the target's ID and associate it with the factory in FORMATS_BY_FACTORY. (#setCustomFormatForFactory(SimpleFramebufferFactory, TextureFormat))
    1. When the factory has its SimpleFramebufferFactory#create() method run, we remove the factory's custom texture format map entry and place it in FORMAT. (#prepareCustomFormatForFramebufferInit(SimpleFramebufferFactory))
    1. In the framebuffer's constructor, we then take the format from FORMAT and use it. (#getCustomFormatForFramebufferInit())
